### PR TITLE
Fixed Issue and improve loading

### DIFF
--- a/src/Typhography.ts
+++ b/src/Typhography.ts
@@ -77,7 +77,7 @@ export const Typhography = {
     font-weight: bold;
     font-stretch: normal;
     font-style: normal;
-    line-height: normal;
+    line-height: 1.6;
     letter-spacing: 0.15px;
     color: ${({ theme }): string => theme.fontColor};
   `,

--- a/src/components/atoms/Image.tsx
+++ b/src/components/atoms/Image.tsx
@@ -1,0 +1,82 @@
+import React, {
+  ReactElement,
+  useEffect,
+  useRef,
+  useState,
+  CSSProperties,
+} from 'react';
+import styled from 'styled-components';
+import DefaultImage from '../../assets/card_placeholder.png';
+
+const CardImage = styled('img')`
+  display: flex;
+  flex: 1;
+  max-height: 11.25rem;
+  width: 100%;
+  object-fit: cover;
+  border-radius: 1.25rem 1.25rem 0 0;
+  &:focus {
+    opacity: 0.75;
+  }
+  &:hover {
+    opacity: 0.75;
+    cursor: pointer;
+  }
+  &:active {
+    opacity: 0.75;
+  }
+`;
+
+interface Props
+  extends React.DetailedHTMLProps<
+    React.ImgHTMLAttributes<HTMLImageElement>,
+    HTMLImageElement
+  > {}
+
+const LOAD_IMG_EVENT_TYPE = 'loadImage';
+
+export default function Image({ src, style, ...props }: Props): ReactElement {
+  let observer: IntersectionObserver | null = null;
+  const imgRef = useRef<HTMLImageElement>(null);
+  const observerRef = useRef<IntersectionObserver>();
+  const [isLoad, setIsLoad] = useState<boolean>(false);
+
+  useEffect(() => {
+    function loadImage() {
+      setIsLoad(true);
+    }
+    const imgEl = imgRef.current;
+    imgEl && imgEl.addEventListener(LOAD_IMG_EVENT_TYPE, loadImage);
+    return () => {
+      imgEl && imgEl.removeEventListener(LOAD_IMG_EVENT_TYPE, loadImage);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!observer) {
+      observer = new IntersectionObserver(onIntersection, {
+        // 확인을 위해 이미지 절반이 나타날 때 로딩한다.
+        threshold: 0.5,
+      });
+    }
+    imgRef.current && observer.observe(imgRef.current);
+  }, []);
+
+  function onIntersection(
+    entries: IntersectionObserverEntry[],
+    io: IntersectionObserver,
+  ) {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        io.unobserve(entry.target);
+        entry.target.dispatchEvent(new CustomEvent(LOAD_IMG_EVENT_TYPE));
+      }
+    });
+  }
+
+  return (
+    <CardImage {...props} ref={imgRef} src={isLoad ? src : DefaultImage} />
+  );
+}
+
+Image.defaultProps = {} as Partial<Props>;

--- a/src/components/elements/Card.tsx
+++ b/src/components/elements/Card.tsx
@@ -5,6 +5,7 @@ import { colors } from '../../theme';
 import { Typhography } from '../../Typhography';
 import { WebtoonPlatform } from '../../types';
 
+import Image from '../atoms/Image';
 import Icon from '../../Icon/Icon';
 import PlatformIcon from '../../Icon/PlatformIcon';
 import DefaultImage from '../../assets/card_placeholder.png';
@@ -99,7 +100,7 @@ function Card(props: Props): ReactElement {
   } = props;
   return (
     <CardContainer>
-      <CardImage
+      <Image
         referrerPolicy="no-referrer"
         onClick={onCardClick}
         src={thumbnail || DefaultImage}

--- a/src/components/elements/PlatformNavigation.tsx
+++ b/src/components/elements/PlatformNavigation.tsx
@@ -35,9 +35,11 @@ const IconWrapper = styled.li`
 function PlatformNavigation({}: Props): ReactElement {
   return (
     <Wrapper>
-      <IconWrapper>
-        <Icon icon="Search" color="white" size={16} />
-      </IconWrapper>
+      <Link to={'/search'}>
+        <IconWrapper>
+          <Icon icon="Search" color="white" size={16} />
+        </IconWrapper>
+      </Link>
       {PlatformIconTypes.map((platform, index) => (
         <List key={index}>
           <Link to={`/platform/${platform.toLowerCase()}`}>

--- a/src/components/elements/SearchBar.tsx
+++ b/src/components/elements/SearchBar.tsx
@@ -61,14 +61,14 @@ export default function SearchBar({
   onChange,
   onClick,
 }: Props): ReactElement {
-  const { text: value, onChange: onChangeText } = useInput(); // 임시로 달아놓음 추후 부모로 옮겨야함
   return (
     <Templete>
       <Input
+        autoFocus
         onClick={onClick}
         placeholder={placeholder}
-        value={value}
-        onChange={onChangeText}
+        value={text}
+        onChange={onChange}        
       />
       <IconWrapper>
         <Icon icon="Search" size={16} />

--- a/src/components/navigation/SwitchNavigator.tsx
+++ b/src/components/navigation/SwitchNavigator.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import React, { ReactElement } from 'react';
 
 import Home from '../screen/Home';
+import Search from '../screen/Search';
 import Platform from '../screen/Platform';
 // import Temp from '../screen/Temp';
 
@@ -11,6 +12,7 @@ function SwitchNavigator(): ReactElement {
       <div style={{ textAlign: 'center' }}>
         <Switch>
           <Route exact={true} path="/" component={Home} />
+          <Route exact={true} path="/search" component={Search} />
           <Route exact={true} path="/platform/:platform" component={Platform} />
           {/* <Route component={Temp} /> */}
           <Redirect path="*" to="/" />

--- a/src/components/screen/Home.tsx
+++ b/src/components/screen/Home.tsx
@@ -110,12 +110,16 @@ function Home({ match }: RouteComponentProps<MatchParams>): ReactElement {
           <Label text={getString('MYTOONMARK')} fontType="H5Medium" />
         </TitleWrapper>
         <WeekSelector selectedItem={selectedDay} handleClick={handleDayClick} />
-        {favorWebtoons.length > 0 ? (
+        {favorWebtoons.filter((value) =>
+          selectedDay !== 'ALL'
+            ? value.weekday.toUpperCase().includes(selectedDay)
+            : value,
+        ).length > 0 ? (
           <CardSection>
             {favorWebtoons
               .filter((value) =>
                 selectedDay !== 'ALL'
-                  ? value.weekday.toUpperCase() === selectedDay
+                  ? value.weekday.toUpperCase().includes(selectedDay)
                   : value,
               )
               .map((webtoon, idx, array) => (

--- a/src/components/screen/Platform.tsx
+++ b/src/components/screen/Platform.tsx
@@ -116,15 +116,15 @@ function Platform({
             .map((e) => data[e]),
         // .sort((a, b) => (a.title > b.title ? 1 : a.title < b.title ? -1 : 0)),
       );
+      setLoading(false);
     } catch (error) {
       if (Axios.isCancel(error)) {
-        console.log('caught cancel :: ', loading);
+        // console.log('caught cancel :: ', loading);
       } else {
         setError(error);
         throw error;
+        setLoading(false);
       }
-    } finally {
-      setLoading(false);
     }
   }
 

--- a/src/components/screen/Search.tsx
+++ b/src/components/screen/Search.tsx
@@ -1,0 +1,176 @@
+import React, { Fragment, ReactElement, useState, useEffect } from 'react';
+import styled from 'styled-components';
+import Axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { IWebtoon } from '../../types';
+import HeaderTemplate from '../templete/HeaderTemplate';
+import { useInput } from '../../hooks';
+import { RouteComponentProps } from 'react-router-dom';
+import Label from '../atoms/Label';
+import { getString } from '../../../STRINGS';
+import { useAppContext } from '../../providers/AppProvider';
+import Card from '../elements/Card';
+
+interface MatchParams {}
+
+const Container = styled.div`
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+  align-self: stretch;
+  overflow: scroll;
+  background: ${(props): string => props.theme.background};
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+  justify-content: flex-start;
+  align-items: flex-start;
+  margin: 0 12.85vw;
+  height: 100%;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  align-self: stretch;
+  padding: 2.5rem 0;
+  overflow: visible;
+`;
+
+const CardSection = styled.div`
+  width: 100%;
+  padding: 2.5rem 0;
+  display: grid;
+  justify-content: center;
+  align-content: flex-start;
+  grid-gap: 1.25rem 1rem;
+  grid-template-columns: repeat(auto-fill, 13.375rem);
+  grid-auto-rows: minmax(20.25rem, auto);
+`;
+
+const EmptyTextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  overflow: visible;
+`;
+
+const baseURL = '/api/webtoon/search/';
+
+export default function Search({
+  history,
+  location,
+}: RouteComponentProps<MatchParams>): ReactElement {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<any>(null);
+  const { text, onChange: onChangeText } = useInput(''); // 임시로 달아놓음 추후 부모로 옮겨야함
+  const [response, setResponse] = useState<IWebtoon[]>([]);
+
+  const {
+    state: { favorWebtoons },
+    setFavorWebtoon,
+  } = useAppContext();
+
+  useEffect(() => {
+    const delayDebounceSearch = setTimeout(async () => {
+      history.push(`/search?query=${text}`);
+      await fetchData(baseURL + text);
+    }, 475);
+    return () => clearTimeout(delayDebounceSearch);
+  }, [text]);
+
+  async function fetchData(
+    url: string,
+    options?: AxiosRequestConfig,
+  ): Promise<void> {
+    const baseOptions: AxiosRequestConfig = {
+      method: 'GET',
+      headers: new Headers({
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'x-dsi-restful': '1',
+      }),
+      ...options,
+    };
+    try {
+      setLoading(true);
+      const res: AxiosResponse<IWebtoon[]> = await Axios(url, baseOptions);
+      const data = (await res.data) as IWebtoon[];
+      setResponse(
+        (prevData) =>
+          prevData
+            .concat(data)
+            .map((e) => e.id)
+            .map((e, i, final) => final.indexOf(e) === i && i)
+            .filter((e) => data[e])
+            .map((e) => data[e]),
+        // .sort((a, b) => (a.title > b.title ? 1 : a.title < b.title ? -1 : 0)),
+      );
+    } catch (error) {
+      if (Axios.isCancel(error)) {
+        console.log('caught cancel :: ', loading);
+      } else {
+        setError(error);
+        throw error;
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const onCardClick = (link: string) => (
+    event?: React.MouseEvent<HTMLElement, MouseEvent>,
+  ): void => {
+    event.preventDefault();
+    window.open(link);
+    window.focus();
+  };
+
+  const onHeartClick = (webtoon: IWebtoon) => (
+    event?: React.MouseEvent<SVGSVGElement, MouseEvent>,
+  ): void => {
+    event.preventDefault();
+    setFavorWebtoon(webtoon);
+  };
+
+  return (
+    <Container>
+      <HeaderTemplate isSearch text={text} onChangeText={onChangeText} />
+      <ContentWrapper>
+        <TitleWrapper>
+          {response.length > 0 ? (
+            <Fragment>
+              <Label text="총" fontType="H6Medium" />
+              <Label text={` ${response.length}개`} fontType="H6Bold" />
+              <Label text="의 웹툰을 찾았습니다" fontType="H6Medium" />
+            </Fragment>
+          ) : (
+            <Label text="검색" fontType="H5Medium" />
+          )}
+        </TitleWrapper>
+        <CardSection>
+          {response.map((webtoon, idx, array) => (
+            <Card
+              key={webtoon.id}
+              platform={webtoon.platform}
+              thumbnail={webtoon.thumbnail}
+              title={webtoon.title}
+              onCardClick={onCardClick(webtoon.link)}
+              onHeartClick={onHeartClick(webtoon)}
+              favor={favorWebtoons.some((data) => data.id === webtoon.id)}
+            />
+          ))}
+        </CardSection>
+      </ContentWrapper>
+    </Container>
+  );
+}
+
+Search.defaultProps = {} as Partial<MatchParams>;

--- a/src/components/templete/HeaderTemplate.tsx
+++ b/src/components/templete/HeaderTemplate.tsx
@@ -14,6 +14,8 @@ import PlatformNavigation from '../elements/PlatformNavigation';
 
 interface Props {
   isSearch?: boolean;
+  text?: string;
+  onChangeText?: (event?: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const ThemeToggleWrapper = styled.div`
@@ -73,7 +75,11 @@ const HeaderRight = styled.nav`
   }
 `;
 
-export default function HeaderTemplate({ isSearch }: Props): ReactElement {
+export default function HeaderTemplate({
+  isSearch,
+  text,
+  onChangeText,
+}: Props): ReactElement {
   const { changeThemeType, themeType } = useThemeContext();
   const [themeSwitch, setThemeSwitch] = useState<boolean>(
     themeType !== ThemeType.LIGHT,
@@ -108,7 +114,11 @@ export default function HeaderTemplate({ isSearch }: Props): ReactElement {
         </TitleWrapper>
       </HeaderLeft>
       <HeaderRight>
-        {isSearch ? <SearchBar /> : <PlatformNavigation />}
+        {isSearch ? (
+          <SearchBar text={text} onChange={onChangeText} />
+        ) : (
+          <PlatformNavigation />
+        )}
       </HeaderRight>
     </HeaderLayout>
   );


### PR DESCRIPTION
- [x] 1. 요일 로딩중 다른 요일 누르면 실패뜨면서 그 전 화면 유지
- 문제 원인 : fetching 취소시에도 finally에서 항상 loading을 true값으로 바꿔주다보니 충돌이 일어나 발생하던 오류
- 해결  finally 구문을 제거하고 loading을 직접 제어 방식으로 제어

- [ ] 2. 요일 버튼을 누를때마다 새로 요청하고 데이터도 다시 받아옴
- 문제 원인 : 버튼 클릭시 새로 요청
- 해결 방안 : 요청이 없어 보류

- [x] 3. 전체버튼을 누를경우 모든 이미지를 로딩함
- 문제 원인 : 요청시 한꺼번에 응답하는 이미지의 갯수가 많아 초기 로딩이 김
- 해결 : interection observer를 통해 image lazy load 적용

- [x] 4. 복수의 연재요일을 가지고 있는 웹툰의 경우 즐겨찾기에 요일 목록에서 노출되지 않음
- 문제 원인 : ,로 연결되어있는 요일을 확인하지 못하고 ===으로 매칭
- 해결 : include를 사용하여 해당 요일 포함여부 확인